### PR TITLE
Support of yaml config format for install-backend command implementation

### DIFF
--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -518,7 +518,7 @@ def _create_secret(name, data, api, namespace='default', force=False):
     secret = {
         'apiVersion': 'v1',
         'data': {
-            'config.json': base64.b64encode(json.dumps(data).encode('utf-8')).decode(),
+            'config': base64.b64encode(json.dumps(data).encode('utf-8')).decode(),
         },
         'kind': 'Secret',
         'metadata': {
@@ -572,7 +572,7 @@ def _create_deployment(name, image, api, healthcheck_path='/', replicas=2,
                             'env': [
                                 {
                                     'name': 'CONFIG_FILE',
-                                    'value': '/config/config.json',
+                                    'value': '/config/config',
                                 },
                             ],
                             'livenessProbe': {

--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -155,8 +155,11 @@ class APSConnectUtil:
         """ Install connector-backend in the k8s cluster"""
 
         try:
-            config_data = json.load(open(config_file))
+            config_data = yaml.load(open(config_file))
             print("Loading config file: {}".format(config_file))
+        except yaml.YAMLError as e:
+            print('Config file should be valid JSON or YAML, error: {}'.format(e))
+
         except Exception as e:
             print("Unable to read config file, error: {}".format(e))
             sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_reqs = parse_requirements(os.path.join(os.path.dirname(os.path.abspath(_
 setup(
     name='apsconnectcli',
     author='Alexander Khaerov',
-    version='1.6.4',
+    version='1.6.5',
     keywords='aps apsconnect connector automation',
     extras_require={
         ':python_version<="2.7"': ['backports.tempfile==1.0rc1']},

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_reqs = parse_requirements(os.path.join(os.path.dirname(os.path.abspath(_
 setup(
     name='apsconnectcli',
     author='Alexander Khaerov',
-    version='1.6.3',
+    version='1.6.4',
     keywords='aps apsconnect connector automation',
     extras_require={
         ':python_version<="2.7"': ['backports.tempfile==1.0rc1']},


### PR DESCRIPTION
Both formats are supported now:
`apsconnect install-backend --name connector_name --image image --config-file config_file`

Config file can be:
```
{
  "debug": true,
  "default_user_limit": 10,
  "devices_resource": "DEVICES",
  "diskspace_resource": "DISKSPACE",
  "fallball_service_authorization_token": "<token>",
  "fallball_service_url": "http://fallball.io",
  "gold_user_limit": 15,
  "gold_users_resource": "GOLD_USERS",
  "oauth_key": "<key>",
  "oauth_secret": "<secret>",
  "users_resource": "USERS"
}
```
or
```
debug: true
default_user_limit: 10
devices_resource: DEVICES
diskspace_resource: DISKSPACE
fallball_service_authorization_token: token
fallball_service_url: http://fallball.io
gold_user_limit: 15
gold_users_resource: GOLD_USERS
oauth_key: key
oauth_secret: secret
users_resource: USERS
```
