### PR TITLE
Fix issue with json.load for python3.5

### DIFF
--- a/apsconnectcli/apsconnect.py
+++ b/apsconnectcli/apsconnect.py
@@ -307,7 +307,7 @@ class APSConnectUtil:
                       "Error: {}".format(connector_id, response.status_code, err))
 
             # Create app, tenant, users resource types
-            resource_uid = json.loads(response.content)['app']['aps']['id']
+            resource_uid = json.loads(response.content.decode('utf-8'))['app']['aps']['id']
 
             core_resource_types_payload = [
                 {

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_reqs = parse_requirements(os.path.join(os.path.dirname(os.path.abspath(_
 setup(
     name='apsconnectcli',
     author='Alexander Khaerov',
-    version='1.6.5',
+    version='1.6.6',
     keywords='aps apsconnect connector automation',
     extras_require={
         ':python_version<="2.7"': ['backports.tempfile==1.0rc1']},


### PR DESCRIPTION
`json.load` for Python 3.5 does not handle bytes string on the fly so it cannot proceed with resources creation:
```
Error: the JSON object must be str, not 'bytes'
```
 This pull request fixes this issue